### PR TITLE
Quick fix for #15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ crash-reports/
 *.launch
 *.lnk
 *.jks
+
+\.idea/
+classes/
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,22 @@ minecraft {
    makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
-dependencies {
-
-
+repositories {
+    maven { // JEI & Tinkers
+        name 'DVS1 Maven FS'
+        url 'http://dvs1.progwml6.com/files/maven'
+    }
+    maven { // CraftTweaker (aka MineTweaker3), Immersive Engineering
+        name 'jared maven'
+        url "http://blamejared.com/maven"
+    }
 }
+
+dependencies {
+    compileOnly "mezz.jei:jei_1.12.2:4.11.+"
+    compileOnly "CraftTweaker2:CraftTweaker2-API:4.1.9.+"
+}
+
 
 processResources
 {

--- a/src/main/java/elucent/rootsclassic/entity/EntityTileAccelerator.java
+++ b/src/main/java/elucent/rootsclassic/entity/EntityTileAccelerator.java
@@ -32,6 +32,13 @@ public class EntityTileAccelerator extends Entity {
   @Override
   public void onUpdate() {
     super.onUpdate();
+    if (pos == null) {
+      if (!world.isRemote) {
+        this.setDead();
+        this.getEntityWorld().removeEntity(this);
+      }
+      return;
+    }
     if (this.getEntityWorld().getTileEntity(this.pos) instanceof ITickable) {
       for (int i = 0; i < potency; i++) {
         ((ITickable) this.getEntityWorld().getTileEntity(this.pos)).update();


### PR DESCRIPTION
This is a quick fix so players can recover their worlds if they used the buggy acceleration spells.

From the look of it, there's lots of issues in the mod, so I'm not motivate to fix it further. Here's a non exhaustive list:
- most spells are bypassing PvP and protected areas
- SunFlower will crash client (NPE in ComponentSunflower.java:37)
- rendering isn't finished on acceleration spells (we can see the default white box
- entities aren't registered properly (should go through events and EntityEntry)
- entityAccelerator is holding the entity object instead of a WeakReference or ID, hence causing a memory leak. It also fails to check the sanity of said entity.