### PR TITLE
Increased Forge version range limit

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -22,7 +22,7 @@ Classic port of Roots, the Druidic Magic Mod
 [[dependencies.rootsclassic]]
     modId="forge" 
     mandatory=true 
-    versionRange="[47,47.1.3]" 
+    versionRange="[47,]" 
     ordering="NONE"
     side="BOTH"
 # Here's another dependency


### PR DESCRIPTION
Increased the Forge version range limit as to allow it to run on NeoForge 1.20.1 as well as on newer versions of Forge 1.20.1

Tested locally and encountered zero issues with Neoforge 1.20.1-47.1.99.

---

Resolves #99, #100, and #102