### PR TITLE
Fix syntax errors in Russian localization.

### DIFF
--- a/src/main/resources/assets/rootsclassic/lang/ru_ru.json
+++ b/src/main/resources/assets/rootsclassic/lang/ru_ru.json
@@ -515,7 +515,7 @@
     "rootsclassic.brazier.burning.added": "Предмет добавлен",
     "rootsclassic.brazier.burning.empty": "Пустая",
     "rootsclassic.brazier.burning.off": "Не подожжена",
-    "rootsclassic.brazier.burning.on": "Жаровня сейчас подожжена."
+    "rootsclassic.brazier.burning.on": "Жаровня сейчас подожжена.",
    
     "rootsclassic.gui.jei.category.mortar": "Ступка",
     "rootsclassic.gui.jei.category.ritual": "Ритуал",


### PR DESCRIPTION
Hello, I found a JSON syntax error in the Russian localization file that was causing those entries to fail during loading. This PR resolves the issue and will allow them to load again.