### PR TITLE
miscellaneous Runic Tablet tweaks

### DIFF
--- a/src/main/java/elucent/rootsclassic/client/screen/TabletPageScreen.java
+++ b/src/main/java/elucent/rootsclassic/client/screen/TabletPageScreen.java
@@ -50,18 +50,9 @@ public class TabletPageScreen extends Screen {
   }
 
   @Override
-  public boolean keyPressed(int keyCode, int scanCode, int modifiers) { // Used to be keyTyped
-    if (keyCode == 256) {
-      minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
-      this.minecraft.setScreen(new TabletScreen(player));
-      return true;
-    }
-    return super.keyPressed(keyCode, scanCode, modifiers);
-  }
-
-  @Override
-  public boolean shouldCloseOnEsc() {
-    return false;
+  public void onClose() {
+    minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+    this.minecraft.setScreen(new TabletScreen(player));
   }
 
   @Override

--- a/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
+++ b/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
@@ -50,7 +50,7 @@ public class TabletScreen extends Screen {
 
   @Override
   public boolean mouseClicked(double mouseX, double mouseY, int button) {
-    float basePosX = (width / 2.0f) - 91;
+    float basePosX = (width / 2.0f) - 92;
     ResearchGroup group = null;
     ResearchBase base = null;
     for (int i = 0; i < ResearchManager.globalResearches.get(currentGroup).researches.size(); i++) {
@@ -134,7 +134,7 @@ public class TabletScreen extends Screen {
       tesselator.end();
       RenderSystem.disableBlend();
     }
-    int basePosX = (int) ((width / 2.0f) - 91);
+    int basePosX = (int) ((width / 2.0f) - 92);
     String researchName = "rootsclassic.research." + ResearchManager.globalResearches.get(currentGroup).getName();
     for (int i = 0; i < ResearchManager.globalResearches.get(currentGroup).researches.size(); i++) {
       int yShift = (int) (float) Math.floor(i / 6);

--- a/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
+++ b/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
@@ -76,16 +76,16 @@ public class TabletScreen extends Screen {
       }
     }
     if (mouseX >= 32 && mouseX < 64 && mouseY >= height - 48 && mouseY < height - 32) {
+      minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
       currentGroup--;
       if (currentGroup < 0) {
-        minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
         currentGroup = ResearchManager.globalResearches.size() - 1;
       }
     }
     if (mouseX >= width - 64 && mouseX < width - 32 && mouseY >= height - 48 && mouseY < height - 32) {
+      minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
       currentGroup++;
       if (currentGroup == ResearchManager.globalResearches.size()) {
-        minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
         currentGroup = 0;
       }
     }

--- a/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
+++ b/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
@@ -50,7 +50,7 @@ public class TabletScreen extends Screen {
 
   @Override
   public boolean mouseClicked(double mouseX, double mouseY, int button) {
-    float basePosX = (width / 2.0f) - 90;
+    float basePosX = (width / 2.0f) - 91;
     ResearchGroup group = null;
     ResearchBase base = null;
     for (int i = 0; i < ResearchManager.globalResearches.get(currentGroup).researches.size(); i++) {
@@ -134,7 +134,7 @@ public class TabletScreen extends Screen {
       tesselator.end();
       RenderSystem.disableBlend();
     }
-    int basePosX = (int) ((width / 2.0f) - 90);
+    int basePosX = (int) ((width / 2.0f) - 91);
     String researchName = "rootsclassic.research." + ResearchManager.globalResearches.get(currentGroup).getName();
     for (int i = 0; i < ResearchManager.globalResearches.get(currentGroup).researches.size(); i++) {
       int yShift = (int) (float) Math.floor(i / 6);

--- a/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
+++ b/src/main/java/elucent/rootsclassic/client/screen/TabletScreen.java
@@ -50,7 +50,7 @@ public class TabletScreen extends Screen {
 
   @Override
   public boolean mouseClicked(double mouseX, double mouseY, int button) {
-    float basePosX = (width / 2.0f) - 108;
+    float basePosX = (width / 2.0f) - 90;
     ResearchGroup group = null;
     ResearchBase base = null;
     for (int i = 0; i < ResearchManager.globalResearches.get(currentGroup).researches.size(); i++) {
@@ -134,7 +134,7 @@ public class TabletScreen extends Screen {
       tesselator.end();
       RenderSystem.disableBlend();
     }
-    int basePosX = (int) ((width / 2.0f) - 108);
+    int basePosX = (int) ((width / 2.0f) - 90);
     String researchName = "rootsclassic.research." + ResearchManager.globalResearches.get(currentGroup).getName();
     for (int i = 0; i < ResearchManager.globalResearches.get(currentGroup).researches.size(); i++) {
       int yShift = (int) (float) Math.floor(i / 6);


### PR DESCRIPTION
* On TabletScreen, translate 92 pixels left of center instead of 108 pixels. This does a better job centering the 6 columns of researches on the screen.

![image](https://github.com/user-attachments/assets/ab367338-f21a-445b-b5b9-48e5690913b6)

* Always play the click sound when you click the left and right arrows on TabletScreen. Previously it only happened when you rolled over from page 3 to page 1, I think this was just a misplaced line of code.
* Reopen TabletScreen from `TabletPageScreen#onClose` instead of listening for the escape key. This is the more "correct" way to do it, and should cause Quark's Back Button Keybind [to actually go back](https://github.com/VazkiiMods/Quark/blob/edbc18e5799f7137504fda89acf45ffe5afddb85/src/main/java/org/violetmoon/quark/content/client/module/BackButtonKeybindModule.java#L79) instead of closing the whole GUI.