### PR TITLE
Fix Engraved Blade, Crystal Staff imbuement, and Time Shift rituals by allowing ritual effects to drive the incense matching process

### DIFF
--- a/src/main/java/elucent/rootsclassic/block/altar/AltarBlockEntity.java
+++ b/src/main/java/elucent/rootsclassic/block/altar/AltarBlockEntity.java
@@ -152,7 +152,7 @@ public class AltarBlockEntity extends BEBase {
           return InteractionResult.FAIL;
         }
         //does it match everything else?
-        if (ritual.incenseMatches(level, pos) || ritual.getIncenses().isEmpty()) {
+        if (ritual.incenseMatches(level, pos)) {
           setRitualCurrent(ritual);
           setIncenses(RitualRegistry.getIncenses(levelAccessor, pos));
           setProgress(RECIPE_PROGRESS_TIME);

--- a/src/main/java/elucent/rootsclassic/recipe/RitualRecipe.java
+++ b/src/main/java/elucent/rootsclassic/recipe/RitualRecipe.java
@@ -179,7 +179,7 @@ public class RitualRecipe<C> implements Recipe<Container> {
         incenseFromNearby.add(brazier.getHeldItem());
       }
     }
-    return RootsUtil.matchesIngredients(incenseFromNearby, incenses);
+    return effect.incenseMatches(incenseFromNearby, this);
   }
 
   public void doEffect(Level levelAccessor, BlockPos pos, Container inventory, List<ItemStack> incenses) {

--- a/src/main/java/elucent/rootsclassic/ritual/RitualEffect.java
+++ b/src/main/java/elucent/rootsclassic/ritual/RitualEffect.java
@@ -2,6 +2,8 @@ package elucent.rootsclassic.ritual;
 
 import java.util.List;
 import com.google.gson.JsonObject;
+import elucent.rootsclassic.recipe.RitualRecipe;
+import elucent.rootsclassic.util.RootsUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -29,4 +31,8 @@ public abstract class RitualEffect<C> {
   abstract public void toNetwork(C config, FriendlyByteBuf buffer);
 
   abstract public C fromNetwork(FriendlyByteBuf buffer);
+  
+  public boolean incenseMatches(List<ItemStack> incensesFromNearby, RitualRecipe<C> recipe) {
+    return RootsUtil.matchesIngredients(incensesFromNearby, recipe.getIncenses());
+  }
 }

--- a/src/main/java/elucent/rootsclassic/ritual/rituals/RitualEngravedSword.java
+++ b/src/main/java/elucent/rootsclassic/ritual/rituals/RitualEngravedSword.java
@@ -2,7 +2,11 @@ package elucent.rootsclassic.ritual.rituals;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import elucent.rootsclassic.recipe.RitualRecipe;
 import elucent.rootsclassic.registry.RootsRegistry;
+import elucent.rootsclassic.registry.RootsTags;
+import elucent.rootsclassic.util.RootsUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
@@ -64,6 +68,18 @@ public class RitualEngravedSword extends RitualCrafting {
     }
     else {
       tag.putInt(name, 1);
+    }
+  }
+  
+  @Override
+  public boolean incenseMatches(List<ItemStack> incensesFromNearby, RitualRecipe<RitualCraftingConfig> recipe) {
+    List<ItemStack> incensesWithoutBarks = new ArrayList<>(incensesFromNearby);
+    incensesWithoutBarks.removeIf(stack -> stack.is(RootsTags.BARKS));
+    
+    if(incensesFromNearby.size() - incensesWithoutBarks.size() > 4) {
+      return false; //Too much bark.
+    } else {
+      return RootsUtil.matchesIngredients(incensesWithoutBarks, recipe.getIncenses());
     }
   }
 }

--- a/src/main/java/elucent/rootsclassic/ritual/rituals/RitualImbuer.java
+++ b/src/main/java/elucent/rootsclassic/ritual/rituals/RitualImbuer.java
@@ -41,6 +41,11 @@ public class RitualImbuer extends SimpleRitualEffect {
   public boolean incenseMatches(List<ItemStack> incensesFromNearby, RitualRecipe<Void> recipe) {
     List<ItemStack> incensesWithoutPowders = new ArrayList<>(incensesFromNearby);
     incensesWithoutPowders.removeIf(stack -> stack.is(RootsRegistry.SPELL_POWDER.get()));
-    return RootsUtil.matchesIngredients(incensesWithoutPowders, recipe.getIncenses());
+    
+    if(incensesWithoutPowders.size() == incensesFromNearby.size()) {
+      return false; //Need to add at least one spell powder.
+    } else {
+      return RootsUtil.matchesIngredients(incensesWithoutPowders, recipe.getIncenses());
+    }
   }
 }

--- a/src/main/java/elucent/rootsclassic/ritual/rituals/RitualImbuer.java
+++ b/src/main/java/elucent/rootsclassic/ritual/rituals/RitualImbuer.java
@@ -1,10 +1,13 @@
 package elucent.rootsclassic.ritual.rituals;
 
+import java.util.ArrayList;
 import java.util.List;
 import elucent.rootsclassic.Const;
 import elucent.rootsclassic.item.CrystalStaffItem;
+import elucent.rootsclassic.recipe.RitualRecipe;
 import elucent.rootsclassic.registry.RootsRegistry;
 import elucent.rootsclassic.ritual.SimpleRitualEffect;
+import elucent.rootsclassic.util.RootsUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
@@ -32,5 +35,12 @@ public class RitualImbuer extends SimpleRitualEffect {
     }
     inventory.clearContent();
     levelAccessor.getBlockEntity(pos).setChanged();
+  }
+  
+  @Override
+  public boolean incenseMatches(List<ItemStack> incensesFromNearby, RitualRecipe<Void> recipe) {
+    List<ItemStack> incensesWithoutPowders = new ArrayList<>(incensesFromNearby);
+    incensesWithoutPowders.removeIf(stack -> stack.is(RootsRegistry.SPELL_POWDER.get()));
+    return RootsUtil.matchesIngredients(incensesWithoutPowders, recipe.getIncenses());
   }
 }

--- a/src/main/java/elucent/rootsclassic/ritual/rituals/RitualTimeShift.java
+++ b/src/main/java/elucent/rootsclassic/ritual/rituals/RitualTimeShift.java
@@ -2,7 +2,10 @@ package elucent.rootsclassic.ritual.rituals;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import elucent.rootsclassic.recipe.RitualRecipe;
 import elucent.rootsclassic.ritual.SimpleRitualEffect;
+import elucent.rootsclassic.util.RootsUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
@@ -30,6 +33,21 @@ public class RitualTimeShift extends SimpleRitualEffect {
       for (ServerLevel serverLevel : levelAccessor.getServer().getAllLevels()) {
         serverLevel.setDayTime(serverLevel.getDayTime() + (long) shiftAmount);
       }
+    }
+  }
+  
+  @Override
+  public boolean incenseMatches(List<ItemStack> incensesFromNearby, RitualRecipe<Void> recipe) {
+    List<ItemStack> incensesWithoutClocks = new ArrayList<>(incensesFromNearby);
+    incensesWithoutClocks.removeIf(stack -> stack.is(Items.CLOCK));
+    
+    if(incensesFromNearby.size() == incensesWithoutClocks.size()) {
+      //No clocks.
+      return false;
+    } else {
+      //The JSON recipe contains exactly one clock incense, so add back one clock.
+      incensesWithoutClocks.add(new ItemStack(Items.CLOCK));
+      return RootsUtil.matchesIngredients(incensesWithoutClocks, recipe.getIncenses());
     }
   }
 }


### PR DESCRIPTION
I wrote about the problem [here](https://github.com/Lothrazar/RootsClassic/issues/113#issuecomment-2558856183).

This PR makes `RitualRecipe#incenseMatches` delegate to the ritual effect, allowing it to modify the way incense items are matched against the recipe matcher. For example, the Crystal Staff requires one to four spell powders which aren't part of the JSON recipe, so the Crystal Staff ritual effect now strips spell powders before performing the recipe match logic.

This fixes #113, fixes Time Skip only working with exactly one clock, and also properly fixes Crystal Staff imbuement without special-casing rituals with empty incense lists.